### PR TITLE
New transport protocol over TLS

### DIFF
--- a/protocol.md
+++ b/protocol.md
@@ -255,7 +255,7 @@ enum RestoreSessionStatus {
 Sent by the server to a client to create a channel. If it is sent by the client with a random `ChannelId` the server assigns one in the _CreateChannelResponse_ packet.
 ```vpsl
 <Int64 ChannelId><ChannelType:Byte ChannelType>
-((ToClient)<Int64 OwnerId>)
+((ToClient)<Int64 OwnerId><DateTime CreationTime>)
 ((ChannelType.Direct)<Int64 CounterpartId>)
 ```
 ```csharp
@@ -271,7 +271,8 @@ enum ChannelType {
 ### **0x2F** CreateChannelResponse ![networkDown] ###
 The server responds to a _CreateChannel_ packet with this packet. It tells the client about the status and the `ChannelId`.
 ```vpsl
-<Int64 TempChannelId><ChannelCreateStatus:Byte StatusCode><Int64 ChannelId>
+<Int64 TempChannelId><ChannelCreateStatus:Byte StatusCode>
+<Int64 ChannelId><DateTime CreationTime>
 ```
 ```csharp
 enum ChannelCreateStatus {

--- a/protocol.md
+++ b/protocol.md
@@ -107,8 +107,8 @@ During the session restore the server will send `SkipCount = -1` which means the
 ((ToClient)<Int64 SkipCount><DateTime DispatchTime>)
 <MessageFlags:Byte MessageFlags>
 ((MessageFlags.ExternalFile)<Int64 FileId>)
-[
-    <ByteArray ContentPacket>
+[AesHmac/None:ByteArray PacketContent
+    ...
     ((MessageFlags.MediaMessage)<File File>)
 ]
 {UInt16 Dependencies <Int64 AccountId><Int64 MessageId>}
@@ -246,7 +246,6 @@ After initializing a connection, the client can restore a session with this pack
 ```csharp
 enum RestoreSessionStatus {
     Success,
-    InvalidCredentials,
     InvalidSession
 }
 ```
@@ -432,7 +431,9 @@ To change the group channel key, the admin sends an update to each client in the
 @dependency GroupChannelKeyNotify // per account
 <Int64 GroupRevision>{UInt16 Members
 <Int64 AccountId><GroupMemberFlags:Byte Flags>}
-[UInt32 ChannelHistory <Byte[64] ChannelKey><Byte[64] HistoryKey>]
+[AesHmac:ByteArray ChannelHistory
+    <Byte[64] ChannelKey><Byte[64] HistoryKey>
+]
 ```
 ```csharp
 [Flags]

--- a/transport.md
+++ b/transport.md
@@ -1,0 +1,81 @@
+# Transport Protocol
+
+## Introduction
+
+Skynet has been using _VSL_ as transport protocol since the beginning of internal version 4. However, maintaining this library becomes increasingly time-consuming and the file transfer is not scalable at all.
+
+The solution for these problems will be a simple transport protocol that offers Packet boundries and is build on TLS.
+An optimized version of the Skynet Server could use a special proxy for TLS offloading written in C/C++ to achieve further performance improvements compared to VSL.
+
+## Binary format
+
+Just like VSL, the new Skynet transport protocol uses little endian as network byte order.
+
+### General packet
+
+```vspl
+<Int32 PacketMeta>...
+```
+
+```
+Raw bytes (little endian)
+
+| 2B | FF | FF | 00 |
+| ID |    Length    |
+```
+
+The maximum packet size is limited to 2^24-1 Bytes (16 MiB).
+
+```csharp
+void Read()
+{
+    int packetMeta = buffer.ReadInt32();
+    byte packetId = (byte)(packetMeta & 0x000000FF);
+    int contentLength = packetMeta >> 8;
+}
+
+void Write(byte packetId, int contentLength)
+{
+    buffer.WriteInt32(contentLength << 8 | packetId);
+}
+```
+
+### PacketBuffer
+User content always uses little endian byte order and has different length markers. Strings are always UTF-8 encoded.
+
+`String` and `ByteArray` are length prefixed with an `UInt16`.  
+`LongString` and `LongByteArray` are prefixed with an `Int32`.
+
+## File transfer
+
+Unlike VSL the new transport protocol will not offer a full end-to-end encrypted file transfer. Small files (≤ 50 KiB) can be stored inside the channel message packet. Large files are uploaded over HTTPS to a mirror server and can be retrieved on the same way.
+
+### Upload
+
+1. Client requests file upload URL
+2. Skynet server responds with URL
+3. Client uploads file  
+`PUT https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
+4. CDN Server notifies Skynet server on success  
+`POST https://api.skynet.app/filetransfer/{fileId}/completed?token={secretToken}`
+5. CDN Server responds client
+`201 Created`
+
+### Continue aborted upload
+
+1. Client request status  
+`HEAD https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
+2. Client uploads rest of the file with `Content-Range`  
+`PATCH https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
+3. CDN Server notifies Skynet server on success  
+`POST https://api.skynet.app/filetransfer/{fileId}/completed?token={secretToken}`
+4. CDN Server responds client
+`204 No Content`
+
+### Download file
+1. Client requests file download URL
+2. Skynet server responds with URL
+3. Client downloads file possibly with `Content-Range`  
+`GET https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
+4. CDN Server responds client
+`200 OK`

--- a/transport.md
+++ b/transport.md
@@ -43,6 +43,7 @@ void Write(byte packetId, int contentLength)
 ### PacketBuffer
 User content always uses little endian byte order and has different length markers. Strings are always UTF-8 encoded.
 
+`ShortString` and `ShortByteArray` are length prefixed with an `UInt8`.
 `String` and `ByteArray` are length prefixed with an `UInt16`.  
 `LongString` and `LongByteArray` are prefixed with an `Int32`.
 
@@ -50,10 +51,16 @@ User content always uses little endian byte order and has different length marke
 
 Unlike VSL the new transport protocol will not offer a full end-to-end encrypted file transfer. Small files (≤ 50 KiB) can be stored inside the channel message packet. Large files are uploaded over HTTPS to a mirror server and can be retrieved on the same way.
 
+> The domain names are examples and might be different in production.
+
 ### Upload
 
-1. Client requests file upload URL
-2. Skynet server responds with URL
+1. Client requests file upload URL  
+`PUT https://api.skynet.app/filetransfer/upload?session={sessionId}&token={webToken}`
+2. Skynet server responds  
+`307 Temporary Redirect`  
+`Location: ...`  
+`X-Skynet-FileId: {fileId}`
 3. Client uploads file  
 `PUT https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
 4. CDN Server notifies Skynet server on success  
@@ -73,9 +80,12 @@ Unlike VSL the new transport protocol will not offer a full end-to-end encrypted
 `204 No Content`
 
 ### Download file
-1. Client requests file download URL
-2. Skynet server responds with URL
+1. Client requests file download URL  
+`GET https://api.skynet.app/filetransfer/{fileId}?session={sessionId}&token={webToken}`
+2. Skynet server responds  
+`307 Temporary Redirect`  
+`Location: ...`
 3. Client downloads file possibly with `Content-Range`  
 `GET https://cdn.skynet.app/filetransfer/{fileId}?token={signedToken}`
-4. CDN Server responds client
+4. CDN Server responds client  
 `200 OK`


### PR DESCRIPTION
This pull request introduces the most fundamental changes ever made to Skynet protocol v5: _VSL_ and `0x0B ChannelMessage` have been replaced.

### Transport protocol
Even if this might sound like a full rewrite, the only completely new designed part is the file transfer. With framework provided TLS implementations the new transport protocol increases security and simplifies maintainability while necessary lines of code will decrease drastically.

By using smaller length prefixes the packet size is now limited to 16 MiB while strings and arrays are limited to 64 KiB or even 255 byte. This avoids the risk of out of memory crashes without needing to implement complicated checks.

### File transfer
The new file transfer over HTTPS is scalable across multiple file transfer servers, can transfer multiple files at once and supports the continuation of aborted file transfers. With the new ability of ChannelMessages to contain thumbnails or entire files up to 50 KiB makes previews directly accessible for the user and saves a lot of overhead especially for small files.

### Inheritance and sessions
Changing the `ChannelMessage` from a container packet to a packet type simplifies their representation in object oriented languages as inheritance can be used easier.

Sessions have now a globally unique `SessionId` which makes client handling much easier on the server. In order to reduce the important of locally saved key material, the generation of the `KeyHash` has been changed so that the user can effectively prompted to enter its password for important actions as account deletions.